### PR TITLE
Call Math.{min,max}.apply instead of using .reduce

### DIFF
--- a/src/statistics.js
+++ b/src/statistics.js
@@ -38,17 +38,13 @@ module.exports.bigSig = function(arr){
 // Maximum value:
 // Find the greatest value in the array
 module.exports.max = function(arr){
-  return arr.reduce(function(a, b){
-    return Math.max(a, b);
-  });
+  return Math.max.apply(null, arr);
 };
 
 // Minimum value:
 // Find the least value in the array
 module.exports.min = function(arr){
-  return arr.reduce(function(a, b){
-    return Math.min(a, b);
-  });
+  return Math.min.apply(null, arr);
 };
 
 // Mean:


### PR DESCRIPTION
[`Math.min`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/min) and [`Math.max`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/max) both accept > 2 arguments

You can call `Math.max.apply(null, array)` as shown in [this example](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/max#Using_Math.max())

A quick [benchmark](https://esbench.com/bench/58ea5e8499634800a0347cbc) shows it's 5-10x faster than `.reduce`.

<img width="570" alt="screen shot 2017-04-09 at 9 59 25 am" src="https://cloud.githubusercontent.com/assets/57655/24839301/8dcc50b6-1d0c-11e7-9ac4-ba82e414c6bd.png">