### PR TITLE
Fixing Error With Area Under Curve in Calculus.js

### DIFF
--- a/src/calculus.js
+++ b/src/calculus.js
@@ -56,8 +56,8 @@ module.exports.areaUnder = function(expression, data){
   var a = data.start;
   var b = data.finish;
   var F = module.exports.integrate(expression);
-  var Fofa = parseFloat(algebra.plug(F, { symbol: 'x', val: a}));
-  var Fofb = parseFloat(algebra.plug(F, { symbol: 'x', val: b}));
+  var Fofa = parseFloat(eval(algebra.plug(F, { symbol: 'x', val: a})));
+  var Fofb = parseFloat(eval(algebra.plug(F, { symbol: 'x', val: b})));
 
   return Fofb - Fofa;
 };


### PR DESCRIPTION
The program does not work when an integral returns a fraction--it only works when the answer is a whole number (e.g. ∫(0 to 1) of x return 1, instead of 0.5).

To fix this, you need to evaluate the fraction before converting to float.